### PR TITLE
Fix for path handling on Windows 

### DIFF
--- a/src/schema/exporter/Exporter.ts
+++ b/src/schema/exporter/Exporter.ts
@@ -66,10 +66,15 @@ export abstract class Exporter extends Transform<Exporter, boolean, State> {
 
 		var targetPath = this.state.cache.getCachePathSync(new Address(name)) + '.js';
 
+		// Always output forward slashes.
+		// If path.sep is a backslash as on Windows, we need to escape it (as a double-backslash) for it to be a valid Regex.
+		// We are using a Regex because the alternative string.replace(string, string) overload only replaces the first occurance.
+		var separatorRegex = new RegExp(path.sep.replace("\\", "\\\\"), 'g');
+		
 		var relPath = path.relative(
 			this.cacheDir,
 			targetPath
-		).replace(new RegExp(path.sep, 'g'), '/').replace(/\.js$/, '');
+		).replace(separatorRegex, '/').replace(/\.js$/, '');
 
 		if(!relPath.match(/^[./]/)) relPath = './' + relPath;
 


### PR DESCRIPTION
Backlashes were causing invalid regex exceptions.

Fixes #5.